### PR TITLE
upd: Nerf magic helmets (#558)

### DIFF
--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -484,8 +484,9 @@ cchar* character::GetNormalDeathMessage() const
     "done in @k", "defeated @k", "struck down @k", "offed @k", "mowed down @k",
     "taken down @k", "sent to the grave @k", "destroyed @k", "executed @k",
     "slaughtered @k", "annihilated @k", "finished @k", "neutralized @k",
-    "obliterated @k", "snuffed @k", "done away with @k", "put to death @k" };
-  return killed_by[RAND() % 27];
+    "obliterated @k", "snuffed @k", "done away with @k", "put to death @k",
+    "released of this mortal coil @k", "taken apart @k", "unmade @k" };
+  return killed_by[RAND() % 30];
 }
 
 festring character::GetGhostDescription() const

--- a/NEWS
+++ b/NEWS
@@ -11,14 +11,23 @@ Next version
 ------------
 
 Changes:
+
+Fixes:
+
+Version 0.57, released XXth September 2019
+------------------------------------------
+
+Changes:
 * Add Black Market, an end-game shop to spend all excess gold in.
 * Add game lore and fiction to the Doc folder.
-* New "expansive terrain" can help prevent blocking important entrances.
-* Improve item search algorithm.
+* Magic helmets spawn with random material.
+* Switch some helmets from full helmet to normal.
 * Keys very rarely break when used.
 
 Fixes:
 * Clean up code.
+* New "expansive terrain" can help prevent blocking important entrances.
+* Improve item search algorithm.
 * Fix ring detection to work same as scrolls.
 * Enable wishes for empty containers, make empty cans and empty bottles wishable.
 * No rotated pictures for equipments and newly-spawned items.

--- a/Script/item.dat
+++ b/Script/item.dat
@@ -5169,7 +5169,6 @@ helmet
                               25, 10, 5, 2, 1, 25, 5; }
     HelmetBitmapPos = 112, 496;
     EnchantmentPlusChance = 30;
-    SoundResistance = 0;
   }
 
   Config FULL_HELMET;
@@ -5218,99 +5217,69 @@ helmet
 
   Config HELM_OF_PERCEPTION;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
     PostFix = "of piercing perception";
     AffectsPerception = true;
-    MainMaterialConfig == ILLITHIUM;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = LEGIFER;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
-    SoundResistance = 1;
     Alias == "perception";
   }
 
   Config BROKEN|HELM_OF_PERCEPTION;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 2;
     Price = 25;
     AffectsPerception = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_UNDERSTANDING;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
     PostFix = "of understanding";
     AffectsWisdom = true;
-    MainMaterialConfig == UNICORN_HORN;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = SOPHOS;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
-    SoundResistance = 1;
     Alias == "wisdom";
   }
 
   Config BROKEN|HELM_OF_UNDERSTANDING;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 2;
     Price = 25;
     AffectsWisdom = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_BRILLIANCE;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
     PostFix = "of brilliance";
     AffectsIntelligence = true;
-    MainMaterialConfig == ARCANITE;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
-    SoundResistance = 1;
     Alias = { 2, "brilliance", "intelligence"; }
   }
 
   Config BROKEN|HELM_OF_BRILLIANCE;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 2;
     Price = 25;
     AffectsIntelligence = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
@@ -5322,10 +5291,27 @@ helmet
     FormModifier = 25;
     BitmapPos = 48, 32;
     Possibility = 5;
+    NameSingular = "helmet";
+    FlexibleNameSingular = "helmet"; /* using full helmet graphics */
     PostFix = "of attractivity";
     AffectsCharisma = true;
-    MainMaterialConfig == GOLD;
-    MaterialConfigChances == 100;
+    MainMaterialConfig = { 60,
+                           SILVER, MOON_SILVER, GOLD, DARK_GOLD, PLATINUM, ELECTRUM,
+                           TITANITE, ADAMANT, CHAR_COAL, COAL, JET, URANIUM, SOLARIUM,
+                           NEUTRONIUM, MAGIC_CRYSTAL, BLUE_CRYSTAL, GREEN_CRYSTAL,
+                           PURPLE_CRYSTAL, PEARL_GLASS, PETRIFIED_WOOD, PETRIFIED_DARK,
+                           DRAGON_BONE, MAMMOTH_TUSK, OBSIDIAN, JASPER, JACINTH, AGATE,
+                           TOURMALINE, CHALCEDONY, CITRINE, LAPIS_LAZULI, OCCULTUM,
+                           AMBER, OPAL, ONYX, PEARL, CORAL, ROSE_QUARTZ, NETHER_QUARTZ,
+                           AMETHYST, TOPAZ, SAPPHIRE, EMERALD, RUBY, DIAMOND, BLACK_DIAMOND,
+                           JADEITE, MALACHITE, NEPHRITE, BLACK_JADE, RED_JADE, GREEN_JADE,
+                           BLUE_JADE, WHITE_JADE, BRIM_STONE, ALABASTER, HEMATITE,
+                           PYRITE, PRIMORDIAL_ICE, HALCYON; }
+    MaterialConfigChances = { 60,
+                              300, 25, 200, 25, 50, 75, 5, 5, 10, 10, 25, 1, 1, 1,
+                              5, 5, 5, 5, 3, 2, 1, 1, 25, 50, 75, 50, 50, 50, 50, 50,
+                              50, 5, 75, 75, 75, 50, 25, 25, 25, 50, 50, 50, 50, 50,
+                              25, 5, 50, 50, 50, 25, 20, 15, 10, 5, 2, 1, 2, 5, 1, 1; }
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
@@ -5386,58 +5372,60 @@ helmet
     StrengthModifier = 125;
     FormModifier = 25;
     BitmapPos = 48, 32;
+    NameSingular = "helmet";
+    FlexibleNameSingular = "helmet"; /* using full helmet graphics */
+    CoverPercentile = 90;
+    HelmetBitmapPos = 96, 432;
+    SoundResistance = 1;
     Possibility = 1;
     PostFix = "of indomitable will";
     AffectsWillPower = true;
-    MainMaterialConfig == OCTIRON;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = LEGIFER;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    MainMaterialConfig = { 30,
+                           COPPER, BRONZE, VERDIGRIS, DEEP_BRONZE, BRASS, SILVER, MOON_SILVER,
+                           FAIRY_STEEL, MITHRIL, PLATINUM, LEAD, GOLD, DARK_GOLD, DARK_MATTER,
+                           ELECTRUM, NICKEL, COBALT, PIG_IRON, IRON, STEEL, DWARF_STEEL,
+                           METEORIC_STEEL, UKKU_STEEL, BLACK_IRON, SOUL_STEEL, BLOOD_IRON,
+                           BLOOD_STEEL, STAINLESS_STEEL, OMMEL_BONE, OMMEL_TOOTH; }
+    MaterialConfigChances = { 30,
+                              750, 1500, 10, 100, 25, 50, 25, 10, 5, 1, 100, 25, 10,
+                              5, 5, 5, 1, 500, 1000, 300, 100, 50, 10, 50, 15, 50,
+                              15, 50, 10, 5; }
     Alias = { 2, "willpower", "will"; }
   }
 
   Config BROKEN|HELM_OF_WILLPOWER;
   {
     BitmapPos = 64, 32;
-    Possibility = 0;
+    HelmetBitmapPos = 96, 512;
+    Possibility = 1;
     Price = 25;
     AffectsWillPower = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_TELEPATHY;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 5;
     PostFix = "of telepathy";
     GearStates = ESP;
-    MainMaterialConfig == SOUL_STEEL;
-    MaterialConfigChances == 100;
     Price = 100;
     AttachedGod = INFUSCOR;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
     Alias = { 3, "helmet of ESP", "helm of ESP", "cap of ESP"; }
   }
 
   Config BROKEN|HELM_OF_TELEPATHY;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 3;
     Price = 25;
     GearStates = 0;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
@@ -5448,15 +5436,26 @@ helmet
     StrengthModifier = 125;
     FormModifier = 25;
     BitmapPos = 48, 32;
+    NameSingular = "helmet";
+    FlexibleNameSingular = "helmet"; /* using full helmet graphics */
+    CoverPercentile = 90;
+    HelmetBitmapPos = 96, 432;
+    SoundResistance = 1;
     Possibility = 5;
     PostFix = "of teleportation";
     GearStates = TELEPORT;
-    MainMaterialConfig == MITHRIL;
-    MaterialConfigChances == 100;
     Price = 100;
+    MainMaterialConfig = { 30,
+                           COPPER, BRONZE, VERDIGRIS, DEEP_BRONZE, BRASS, SILVER, MOON_SILVER,
+                           FAIRY_STEEL, MITHRIL, PLATINUM, LEAD, GOLD, DARK_GOLD, DARK_MATTER,
+                           ELECTRUM, NICKEL, COBALT, PIG_IRON, IRON, STEEL, DWARF_STEEL,
+                           METEORIC_STEEL, UKKU_STEEL, BLACK_IRON, SOUL_STEEL, BLOOD_IRON,
+                           BLOOD_STEEL, STAINLESS_STEEL, OMMEL_BONE, OMMEL_TOOTH; }
+    MaterialConfigChances = { 30,
+                              750, 1500, 10, 100, 25, 50, 25, 10, 5, 1, 100, 25, 10,
+                              5, 5, 5, 1, 500, 1000, 300, 100, 50, 10, 50, 15, 50,
+                              15, 50, 10, 5; }
     AttachedGod = SOPHOS;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
     Alias = { 3, "helmet of teleport", "helm of teleport", "cap of teleport"; }
   }
@@ -5464,10 +5463,10 @@ helmet
   Config BROKEN|HELM_OF_TELEPORTATION;
   {
     BitmapPos = 64, 32;
+    HelmetBitmapPos = 96, 512;
     Possibility = 3;
     Price = 25;
     GearStates = 0;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
@@ -5501,6 +5500,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    SoundResistance = 1;
     GearStates = INFRA_VISION|SEARCHING;
   }
 
@@ -5522,28 +5522,46 @@ helmet
     StrengthModifier = 125;
     FormModifier = 25;
     BitmapPos = 48, 32;
+    NameSingular = "helmet";
+    FlexibleNameSingular = "helmet"; /* using full helmet graphics */
+    CoverPercentile = 90;
+    HelmetBitmapPos = 96, 432;
+    SoundResistance = 1;
     Possibility = 1;
     PostFix = "of essence plethora";
     Alias = { 3, "helmet of mana", "helm of mana", "cap of mana"; }
     AffectsMana = true;
-    MainMaterialConfig == AMETHYST;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
+    MainMaterialConfig = { 60,
+                           SILVER, MOON_SILVER, GOLD, DARK_GOLD, PLATINUM, ELECTRUM,
+                           TITANITE, ADAMANT, CHAR_COAL, COAL, JET, URANIUM, SOLARIUM,
+                           NEUTRONIUM, MAGIC_CRYSTAL, BLUE_CRYSTAL, GREEN_CRYSTAL,
+                           PURPLE_CRYSTAL, PEARL_GLASS, PETRIFIED_WOOD, PETRIFIED_DARK,
+                           DRAGON_BONE, MAMMOTH_TUSK, OBSIDIAN, JASPER, JACINTH, AGATE,
+                           TOURMALINE, CHALCEDONY, CITRINE, LAPIS_LAZULI, OCCULTUM,
+                           AMBER, OPAL, ONYX, PEARL, CORAL, ROSE_QUARTZ, NETHER_QUARTZ,
+                           AMETHYST, TOPAZ, SAPPHIRE, EMERALD, RUBY, DIAMOND, BLACK_DIAMOND,
+                           JADEITE, MALACHITE, NEPHRITE, BLACK_JADE, RED_JADE, GREEN_JADE,
+                           BLUE_JADE, WHITE_JADE, BRIM_STONE, ALABASTER, HEMATITE,
+                           PYRITE, PRIMORDIAL_ICE, HALCYON; }
+    MaterialConfigChances = { 60,
+                              300, 25, 200, 25, 50, 75, 5, 5, 10, 10, 25, 1, 1, 1,
+                              5, 5, 5, 5, 3, 2, 1, 1, 25, 50, 75, 50, 50, 50, 50, 50,
+                              50, 5, 75, 75, 75, 50, 25, 25, 25, 50, 50, 50, 50, 50,
+                              25, 5, 50, 50, 50, 25, 20, 15, 10, 5, 2, 1, 2, 5, 1, 1; }
     PriceIsProportionalToEnchantment = true;
     AttachedGod = SOPHOS;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
   }
 
   Config BROKEN|HELM_OF_MANA;
   {
     BitmapPos = 64, 32;
-    Possibility = 0;
+    HelmetBitmapPos = 96, 512;;
+    Possibility = 1;
     Price = 25;
     AffectsMana = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 


### PR DESCRIPTION
* Nerf magic helmet, attempt II

Magic helmets with pre-defined materials are too strong, as they appear
early with good material AND a magical effect.

Make magic helmets use randomized materials. Their magic effects should
be good enough to make them competitive with other helmets.

Also switch most magic helmets to normal helmet, rather than full
helmet. This allows full helmets to be more distinct, as they will offer
the best coverage and AV.

* Make some magic helmets full again

* No cloth full helmets

I forgot to restore non-flexible-only materials for full helmets.