### PR TITLE
upd from main: Updated installation method for lovers of Microsoft Visual Studio (20…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ elseif(WIN32)
   add_definitions(-D_USE_32BIT_TIME_T)
 endif(UNIX)
 
+# In visual studio 2017, add an option to hide the console window (useful where debugging is not intended - i.e. releases)
+if(MSVC AND MSVC_HIDE_CONSOLE_WINDOW)
+  # Hide the console window in visual studio projects
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
+endif()
+
 if(WIZARD)
   add_definitions(-DWIZARD)
 endif()

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,23 @@
+{
+  "configurations": [
+    {
+      "name": "x86-Release",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DHAVE_CXX14=ON, -DWIZARD=ON, -DMSVC_HIDE_CONSOLE_WINDOW=ON",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_TOOLCHAIN_FILE",
+          "value": "C:\\tools\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+        }
+      ]
+    }
+  ]
+}

--- a/FeLib/CMakeLists.txt
+++ b/FeLib/CMakeLists.txt
@@ -14,16 +14,6 @@ add_library(FeLib ${FELIB_SOURCES})
 
 find_package(SDL2 REQUIRED)
 
-if(MSVC)
-  # Not very pretty solution. This finds SDL2.dll from SDL2.lib path, so that it can be installed where ivan.exe will end up.
-  message("SDL2_LIBRARY ${SDL2_LIBRARY}")
-  list(GET SDL2_LIBRARY 0 sdl_lib_dir)
-  message("sdl_lib_dir ${sdl_lib_dir}")
-  get_filename_component(sdl_lib_dir "${sdl_lib_dir}" DIRECTORY)
-  message("sdl_lib_dir ${sdl_lib_dir}")
-  install(FILES "${sdl_lib_dir}/SDL2.dll" DESTINATION "ivan")
-endif()
-
 if(MINGW)
   # Not very pretty solution. This finds SDL2.dll from SDL2.lib path, so that it can be installed where ivan.exe will end up.
   message("SDL2_LIBRARY ${SDL2_LIBRARY}")
@@ -50,6 +40,14 @@ endif()
 if(NOT PNG_FOUND)
   find_package(PNG REQUIRED)
   add_definitions(${PNG_DEFINITIONS})
+endif()
+
+if(MSVC AND _VCPKG_INSTALLED_DIR)
+  # Gum solution for manually copying dynamic link libraries from the vcpkg bin directory
+  install(FILES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libpng16.dll" DESTINATION "ivan")
+  install(FILES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/zlib1.dll" DESTINATION "ivan")
+  install(FILES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2.dll" DESTINATION "ivan")
+  install(FILES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2_mixer.dll" DESTINATION "ivan")
 endif()
 
 target_include_directories(FeLib PUBLIC Include)

--- a/FeLib/Include/dbgmsgproj.h
+++ b/FeLib/Include/dbgmsgproj.h
@@ -128,7 +128,7 @@
 
     #define DBGCHAR(ch,info)
     #define DBGITEM(it,info)
-    #define DBGABORT(x...)
+    #define DBGABORT(x,...)
 
   #endif //DBGMSG
 

--- a/FeLib/Source/feio.cpp
+++ b/FeLib/Source/feio.cpp
@@ -983,7 +983,7 @@ festring iosystem::ContinueMenu(col16 TopicColor, col16 ListColor,
 //  static festring fsLastChangeDetector="_Last_Change_Detector_.sav";
 //  addFileInfo(fsLastChangeDetector.CStr());
 
-  int iTmSz=100;
+  cint iTmSz=100;
   struct stat attr;
   for(int i=0;i<vFiles.size();i++)
   {

--- a/INSTALL
+++ b/INSTALL
@@ -47,34 +47,52 @@ make -f ivandj.mak
 
 --------------------------------------
 
-Under Windows - Visual Studio:
+Under Windows - Microsoft Visual Studio 2017 (or better):
+
+You will need to install the C++ tools with CMake support, along with Git integrations from the Visual Studio Installer. 
+We will not be using Visual Studio in the traditional way with everything squished into a solution file. 
+Instead we will use Visual Studio to open a repo folder with a top-level CMakeLists.txt, in conjunction with a CMakeSettings.json file to create the cmake build files.
+Then we will use msvc to compile ivan.exe, with the help of libraries we install from vcpkg using Powershell (PS). 
+
+Install vcpkg and install the needed libraries using Powershell:
+Here is a condensed summary of applicable instructions from https://github.com/microsoft/vcpkg
+Create a folder named "tools" under C:\ and clone the vcpkg repository from github:
+PS C:\tools> git clone https://github.com/Microsoft/vcpkg.git
+PS C:\tools> cd vcpkg
+PS C:\tools\vcpkg> ./bootstrap-vcpkg.sh
+PS C:\tools\vcpkg> .\vcpkg integrate install
+
+Install the following libraries:
+PS C:\tools\vcpkg> .\vcpkg install sdl2 sdl2-mixer libpng pcre
+
+Verify the libraries are installed with this command:
+PS C:\tools\vcpkg> .\vcpkg list
+libpng:x86-windows                                 1.6.37-1         libpng is a library implementing an interface fo...
+pcre:x86-windows                                   8.41-2           Perl Compatible Regular Expresions
+sdl2-mixer:x86-windows                             2.0.4-2          Multi-channel audio mixer library for SDL.
+sdl2:x86-windows                                   2.0.9-3          Simple DirectMedia Layer is a cross-platform dev...
+zlib:x86-windows                                   1.2.11-5         A compression library
 
 
-Install SDL2
+Clone attnam/ivan into a directory (for example C:\Users\yourname\source\repos\ivan)
 
-Download SDL2-devel-2.0.4-VC.zip from http://www.libsdl.org/
-and install somewhere in system, e.g. D:\Apps\SDL2-2.0.4
+Open Microsoft Visual Studio (2017)
 
+Go File->Open Folder
 
-Set system environment variable SDL2DIR to "D:\Apps\SDL2-2.0.4".
-Make sure to open command prompt after that (so this variable is taken into account).
+Select C:\Users\yourname\source\repos\ivan
 
-Alternatively set it just in current command prompt:
+Some stuff will happen automatically. The CMakeSettings.json file will be found, and the CMake cache will be generated.
 
-D:\buildy\ivan>set SDL2DIR=D:\Apps\SDL2-2.0.4
+Next to the green "play" button is some text (Select Startup Item...) in a gray dropdown menu. Select "ivan.exe (Install) (ivan\ivan.exe)".
 
+"Build" will appear in the menu next to "CMake". Click Build->ivan.exe (Install) (ivan\ivan.exe) F7
 
-Compile IVAN
+This will build ivan.exe and install all the components, automatically copying the required dlls as well.
 
-Either use cmake-gui if system environment variable was set, or:
+The build folder is located in C:\Users\yourname\CMakeBuilds\some-long-code-here-abcdef123456\install\x86-Release\ivan
+Go there and hit ivan.exe, and you're playing IVAN built using Microsoft Visual Studio!!!
 
-D:\buildy\ivan>mkdir vs2015
-D:\buildy\ivan>cd vs2015
-D:\buildy\ivan\vs2015>cmake -G "Visual Studio 14 2015" .. -DCMAKE_INSTALL_PREFIX=D:/buildy/ivan/inst_vs2015
-
-Now open and compile D:\buildy\ivan\vs2015\ivan.sln in VS2015 IDE.
-
-Now you can run ivan from D:/buildy/ivan/inst_vs2015/ivan/ directory.
 
 --------------------------------------
 

--- a/Main/CMakeLists.txt
+++ b/Main/CMakeLists.txt
@@ -4,6 +4,10 @@ if(PKG_CONFIG_FOUND)
   set(PCRE_LIBRARIES ${PCRE_LDFLAGS})
 endif()
 if(NOT PCRE_FOUND)
+  if(MSVC)
+    find_path(PCRE_INCLUDE_DIR NAMES pcre.h)
+    find_library(PCRE_LIBRARY pcre)
+  endif()
   find_package(PCRE REQUIRED)
   add_definitions(${PCRE_DEFINITIONS})
 endif()
@@ -31,6 +35,11 @@ set_source_files_properties(
 add_executable(ivan ${IVAN_SOURCES} Resource/Ivan.rc)
 target_include_directories(ivan PUBLIC Include ../Felib/Include ../audio ../fantasyname ${PCRE_INCLUDE_DIRS} ${SDL2_mixer_INCLUDE_DIR})
 target_link_libraries(ivan FeLib FeAudio xbrzscale fantasyname ${PCRE_LIBRARIES} ${SDL2_mixer_LIBRARY})
+
+if(MSVC AND _VCPKG_INSTALLED_DIR)
+  # Gum solution. Manually copy pcre.dll to where ivan.exe will end up.
+  install(FILES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/pcre.dll" DESTINATION "ivan")
+endif()
 
 if(UNIX)
     install(TARGETS ivan DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Main/Include/devcons.h
+++ b/Main/Include/devcons.h
@@ -17,7 +17,7 @@
 
 #include "festring.h"
 
-#define DEVCMDMSG(fmt,x...) ADD_MESSAGE(" > " fmt,x);
+#define DEVCMDMSG(fmt,x,...) ADD_MESSAGE(" > " fmt,x);
 
 typedef void (*callcmd)(std::string);
 

--- a/Main/Resource/Ivan.rc
+++ b/Main/Resource/Ivan.rc
@@ -7,7 +7,11 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
+#ifdef WIN32
+#include "windows.h"
+#else
 #include "afxres.h"
+#endif
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -1710,7 +1710,7 @@ void game::DrawMapOverlay(bitmap* buffer)
           int iR=0xFF, iG=0xFF*0.80, iB=0xFF*0.60; //old paper like, well.. should be at least ;)
           float fFrom=0.95;
           float fStep=0.15;
-          int iTot=1.0/fStep;
+          cint iTot=6; // was 1.0/fStep;
           col16 clMap[iTot];
           for(int i=0;i<iTot;i++){
             float f=fFrom -fStep*i;
@@ -3554,7 +3554,7 @@ festring game::SaveName(cfestring& Base,bool bLoadingFromAnAutosave)
 
     if(CurrentBaseSaveFileName.GetSize() == 0)
     {
-      int iTmSz=100; char cTime[iTmSz]; time_t now = time(0);
+      cint iTmSz=100; char cTime[iTmSz]; time_t now = time(0);
       strftime(cTime,iTmSz,"%Y%m%d_%H%M%S",localtime(&now)); //pretty DtTm
 
       CurrentBaseSaveFileName << PlayerName << '_' << cTime;

--- a/cmake/FindPCRE.cmake
+++ b/cmake/FindPCRE.cmake
@@ -1,0 +1,37 @@
+# Copyright (C) 2007-2009 LuaDist.
+# Created by Peter Kapec <kapecp@gmail.com>
+# Redistribution and use of this file is allowed according to the terms of the MIT license.
+# For details see the COPYRIGHT file distributed with LuaDist.
+#	Note:
+#		Searching headers and libraries is very simple and is NOT as powerful as scripts
+#		distributed with CMake, because LuaDist defines directories to search for.
+#		Everyone is encouraged to contact the author with improvements. Maybe this file
+#		becomes part of CMake distribution sometimes.
+
+# - Find pcre
+# Find the native PCRE headers and libraries.
+#
+# PCRE_INCLUDE_DIRS	- where to find pcre.h, etc.
+# PCRE_LIBRARIES	- List of libraries when using pcre.
+# PCRE_FOUND	- True if pcre found.
+
+# Look for the header file.
+FIND_PATH(PCRE_INCLUDE_DIR NAMES pcre.h)
+
+# Look for the library.
+FIND_LIBRARY(PCRE_LIBRARY NAMES pcre)
+
+# Handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if all listed variables are TRUE.
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE DEFAULT_MSG PCRE_LIBRARY PCRE_INCLUDE_DIR)
+
+# Copy the results to the output variables.
+IF(PCRE_FOUND)
+	SET(PCRE_LIBRARIES ${PCRE_LIBRARY})
+	SET(PCRE_INCLUDE_DIRS ${PCRE_INCLUDE_DIR})
+ELSE(PCRE_FOUND)
+	SET(PCRE_LIBRARIES)
+	SET(PCRE_INCLUDE_DIRS)
+ENDIF(PCRE_FOUND)
+
+MARK_AS_ADVANCED(PCRE_INCLUDE_DIRS PCRE_LIBRARIES)

--- a/fantasyname/CMakeLists.txt
+++ b/fantasyname/CMakeLists.txt
@@ -2,4 +2,8 @@ file(GLOB FANTASYNAME_SOURCES namegen.cc namegen.h)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 
+if(HAVE_CXX14)
+  add_definitions(-DHAVE_CXX14)
+endif()
+
 add_library(fantasyname ${FANTASYNAME_SOURCES})


### PR DESCRIPTION
…17) (#559)

* Update all CMakeLists.txt for msvc

Help msvc find pcre.h.

Manually grab some DLLs and put them into the ivan build folder.

Added a couple of new flags:

VCPKG_DLL_BINARY_DIRECTORY - this is where the dlls can be found for the vcpkg suite.
Should be something like "C:\tools\cpkg\installed\x86-windows\bin".

MSVC_HIDE_CONSOLE_WINDOW - Set this to "ON" to hide the console window for an MSVC build of ivan.

HAVE_CXX14 - MSVC 2017 will complain about a certain function already being defined in C++14. Set this flag to "ON" to work around that.

* Add missing commas in some macros

* Make some ints into cints

* Update Ivan.rc with windows.h

* Add missing quotes in FeLib/CMakeLists.txt

* Add FindPCRE.cmake

* Remove VCPKG_DLL_BINARY_DIRECTORY

Replace this with vcpkg native stuff in CMake

* Add CMakeSettings.json

Not sure if this is good practice to just chuck this in the repo, but what the hey.

* Update INSTALL

Updated installation instructions for lovers of Microsoft Visual Studio (2017)