### PR TITLE
Fix Banana Growers blocking the Sumo's door

### DIFF
--- a/Main/Include/bugworkaround.h
+++ b/Main/Include/bugworkaround.h
@@ -23,6 +23,7 @@ class bugfixdp{
     static void init();
     static character* ValidatePlayerAt(square* sqr);
     static bool IsFixing();
+    static std::vector<character*> FindCharactersOnLevel(bool bOnlyPlayers=false);
 
   private:
     static character* BugWorkaroundDupPlayer();
@@ -42,7 +43,6 @@ class bugfixdp{
 
     static character* FindByPlayerID1(v2 ReqPosL,bool bAndFixIt);
     static std::vector<character*> FindByPlayerFlag();
-    static std::vector<character*> FindCharactersOnLevel(bool bOnlyPlayers=false);
     static bool ScanLevelForCharactersAndItemsWork(item*, bool, bool, std::vector<bugWorkaroundDupPlayerCharItem>*);
     static void CollectAllItemsOnLevel(std::vector<item*>* pvAllItemsOnLevel);
     static void CollectAllCharactersOnLevel(std::vector<character*>* pvCharsOnLevel);

--- a/Main/Include/char.h
+++ b/Main/Include/char.h
@@ -1191,6 +1191,7 @@ class character : public entity, public id
   void SetNewVomitMaterial(int What) { MyVomitMaterial = What; }
   festring GetHitPointDescription() const;
   truth WillGetTurnSoon() const;
+  virtual void SetFeedingSumo(truth What) { return; }
  protected:
   static truth DamageTypeDestroysBodyPart(int);
   virtual void LoadSquaresUnder();

--- a/Main/Include/human.h
+++ b/Main/Include/human.h
@@ -655,6 +655,7 @@ CHARACTER(bananagrower, humanoid)
   virtual festring& ProcessMessage(festring&) const;
   virtual truth IsBananaGrower() const { return true; }
   festring GetProfession() const { return Profession; }
+  virtual void SetFeedingSumo(truth What) { FeedingSumo = What; }
  protected:
   virtual truth HandleCharacterBlockingTheWay(character*, v2, int);
   virtual void PostConstruct();

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -6389,6 +6389,17 @@ truth game::EndSumoWrestling(int Result)
     DrawEverything();
   }
 
+  // Send the bananagrowers back to work
+  std::vector<character*> VillagePeople = bugfixdp::FindCharactersOnLevel();
+  for(int j = 0; j < VillagePeople.size(); j++)
+  {
+    character* Villager = VillagePeople[j];
+    if(Villager && dynamic_cast<bananagrower*>(Villager))
+    {
+      Villager->SetFeedingSumo(false);
+    }
+  }
+
   Player->EditNP(-25000);
   Player->CheckStarvationDeath(CONST_S("exhausted after controlling a mirror image for too long"));
   throw areachangerequest();


### PR DESCRIPTION
@AquariusPower how about this? After sumo wrestling, it checks for all the banana growers on the level and sets their `FeedingSumo` flags to false, meaning they change their `MovingTo` target to the banana drop area during their `GetAICommand()`.

The only thing is it requires `static std::vector<character*> FindCharactersOnLevel()` to become a public member of `class bugfixdp`. It's a pretty handy method, some of this stuff could really be generalized to the rest of the code. Could probably make it a method in `level.cpp`.

